### PR TITLE
fix: find account id

### DIFF
--- a/api/src/methods/account.ts
+++ b/api/src/methods/account.ts
@@ -31,7 +31,11 @@ export async function account(session: Session) {
 
   const email = $('#current_email').text();
   const name = $('#current_display_name').text();
-  const id = $('#current_shift_service_id').text();
+  const id = $('form.edit_user').attr('action')?.split('/').at(-1);
+  
+  if (!id) {
+    throw new Error("No account ID found")
+  }
 
   const account: Account = {
     email,


### PR DESCRIPTION
Hi, the element you used to get the account ID from seems to be missing, making the program store an empty string as the current ID. I had to remove `account-.json` and `meta.json` and login again (or edit the files).